### PR TITLE
chore: update WordPress tested version to 6.9

### DIFF
--- a/omnisend-for-surecart/class-omnisend-surecartaddon.php
+++ b/omnisend-for-surecart/class-omnisend-surecartaddon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Omnisend for SureCart Add-On
  * Requires Plugins: surecart
  * Description: A SureCart add-on to sync Products/Categories/Orders/Contacts with Omnisend. In collaboration with SureCart plugin, it also enables better customer tracking
- * Version: 1.0.9
+ * Version: 1.0.10
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
  * Developer: Omnisend
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'OMNISEND_SURECART_ADDON_NAME', 'Omnisend for SureCart Add-On' );
-define( 'OMNISEND_SURECART_ADDON_VERSION', '1.0.9' );
+define( 'OMNISEND_SURECART_ADDON_VERSION', '1.0.10' );
 
 spl_autoload_register( array( 'Omnisend_SureCartAddOn', 'autoloader' ) );
 register_deactivation_hook( __FILE__, array( 'Omnisend_SureCartAddOn', 'deactivation_actions' ) );

--- a/omnisend-for-surecart/readme.txt
+++ b/omnisend-for-surecart/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for SureCart Add-On
 Contributors: omnisend,omnisendcommunity
 Tags: SureCart, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.9
+Stable tag: 1.0.10
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -79,6 +79,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.0.10 =
+* Tested up to WordPress 6.9
 
 = 1.0.9 =
 


### PR DESCRIPTION
## What?
Update WordPress tested version to 6.9 and bump plugin version to 1.0.10.

## Why?
Plugin has been tested with WordPress 6.9.